### PR TITLE
on Ubuntu 18.04.3 I had to add -fPIC to make

### DIFF
--- a/LogToFile/Makefile
+++ b/LogToFile/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-O0 -g -pipe
+CFLAGS=-O0 -g -pipe -fPIC
 CFLAGS+=$(shell python3.8-config --cflags)
 
 LDFLAGS+=$(shell python3.8-config --ldflags --embed)

--- a/LogToStderr/Makefile
+++ b/LogToStderr/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-O0 -g -pipe
+CFLAGS=-O0 -g -pipe -fPIC
 CFLAGS+=$(shell python3.8-config --cflags)
 
 LDFLAGS+=$(shell python3.8-config --ldflags --embed)

--- a/LogToStderrMinimal/Makefile
+++ b/LogToStderrMinimal/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-O0 -g -pipe
+CFLAGS=-O0 -g -pipe -fPIC
 CFLAGS+=$(shell python3.8-config --cflags)
 
 LDFLAGS+=$(shell python3.8-config --ldflags --embed)

--- a/syslog/Makefile
+++ b/syslog/Makefile
@@ -1,5 +1,5 @@
 CC=gcc
-CFLAGS=-O0 -g -pipe
+CFLAGS=-O0 -g -pipe -fPIC
 CFLAGS+=$(shell python3.8-config --cflags)
 
 LDFLAGS+=$(shell python3.8-config --ldflags --embed)


### PR DESCRIPTION
gcc wanted -fPIC so I added it.  Feel free to ignore, just figured I'd share.  I only did the non-Windows ones for obvious reasons.  linux_xattr probably needs it too but I didn't try it cause I'm missing some lib it uses.